### PR TITLE
06

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,23 @@
+06 - join switch code blocks
+
+If we have a look to the current code, we can see that name property is evaluated (switch) in two different parts
+
+There is also a middle part which decrements sellin always except with item Sulfuras
+
+- updateQuality() in GildedRose class:
+    - I will first decrement the sellin variable before the switch block for all except Sulfuras.
+    I could also add in every other case of the switch and avoid one comparison
+    - I will then invert again the condition and extract this code into a method decrementDaysToSell(). 
+    I think the code is clearer 
+    - decrementing sellin at the beginning makes that the conditions for backstage passes are updated to 10 and 5 days
+    This was also stated in the requirements: 
+    "Quality increases by 2 when there are 10 days or less and by 3 when there are 5 days or less"
+    Again, the code is easier to understand
+    - To join the second switch case we have to duplicate the codition 
+    "if (item.sellIn < 0)" in every case of the switch, except Sulfuras 
+    
+---
+
 05 - Simplify if and replace with switch
 
 - updateQuality() in GildedRose class:

--- a/src/main/java/com/gildedrose/GildedRose.java
+++ b/src/main/java/com/gildedrose/GildedRose.java
@@ -1,4 +1,4 @@
-// Revision 05 - Simplify if and replace with switch
+// Revision 06 - join switch code blocks
 package com.gildedrose;
 
 class GildedRose {
@@ -15,43 +15,43 @@ class GildedRose {
     }
 
     private void updateItemQuality(Item item) {
+        decrementDaysToSell(item);
         switch (item.name) {
-            case "Aged Brie":
-                incrementItemQuality(item);
-                break;
-            case "Backstage passes to a TAFKAL80ETC concert":
-                incrementItemQuality(item);
-                if (item.sellIn < 11) {
-                    incrementItemQuality(item);
-                }
-                if (item.sellIn < 6) {
-                    incrementItemQuality(item);
-                }
-                break;
             case "Sulfuras, Hand of Ragnaros":
                 break;
+
+            case "Aged Brie":
+                incrementItemQuality(item);
+                if (item.sellIn < 0) {
+                    incrementItemQuality(item);
+                }
+                break;
+
+            case "Backstage passes to a TAFKAL80ETC concert":
+                incrementItemQuality(item);
+                if (item.sellIn < 10) {
+                    incrementItemQuality(item);
+                }
+                if (item.sellIn < 5) {
+                    incrementItemQuality(item);
+                }
+                if (item.sellIn < 0) {
+                    item.quality = 0;
+                }
+                break;
+
             default:
                 decrementItemQuality(item);
+                if (item.sellIn < 0) {
+                    decrementItemQuality(item);
+                }
                 break;
         }
+    }
 
-        if (item.name.equals("Sulfuras, Hand of Ragnaros")) {
-        } else {
+    private void decrementDaysToSell(Item item) {
+        if (!item.name.equals("Sulfuras, Hand of Ragnaros"))  {
             item.sellIn = item.sellIn - 1;
-        }
-
-        if (item.sellIn < 0) {
-            switch (item.name) {
-                case "Aged Brie":
-                    incrementItemQuality(item);
-                    break;
-                case "Backstage passes to a TAFKAL80ETC concert":
-                    item.quality = 0;
-                    break;
-                case "Sulfuras, Hand of Ragnaros":
-                    return;
-            }
-            decrementItemQuality(item);
         }
     }
 


### PR DESCRIPTION
- updateQuality() in GildedRose class:
    - I will first decrement the sellin variable before the switch block for all except Sulfuras.
    I could also add in every other case of the switch and avoid one comparison
    - I will then invert again the condition and extract this code into a method decrementDaysToSell(). 
    I think the code is clearer 
    - decrementing sellin at the beginning makes that the conditions for backstage passes are updated to 10 and 5 days
    This was also stated in the requirements: 
    "Quality increases by 2 when there are 10 days or less and by 3 when there are 5 days or less"
    Again, the code is easier to understand
    - To join the second switch case we have to duplicate the codition 
    "if (item.sellIn < 0)" in every case of the switch, except Sulfuras 